### PR TITLE
[FIX] 메뉴ID로조회에서 권한없음 현상 해결, 메뉴생성에서 메뉴 유형 없는 부분 수정

### DIFF
--- a/src/components/templates/MenuManagement/CreateMenu.js
+++ b/src/components/templates/MenuManagement/CreateMenu.js
@@ -10,6 +10,7 @@ const MenuCreate = ({ open, toggle }) => {
   // 모달에서 입력된 값을 받아서 저장할 state.
   const [menuCreateFormData, setMenuCreateFormData] = useState({
     menuOrder: '',
+    menuType: '',
     nameEng: '',
     nameKor: '',
     description: '',
@@ -47,6 +48,18 @@ const MenuCreate = ({ open, toggle }) => {
       label: '설명',
       type: 'text',
       value: menuCreateFormData.description
+    },
+    {
+      name: 'menuType',
+      label: '메뉴타입',
+      type: 'select',
+      select: true,
+      SelectProps: [
+        <MenuItem value="FOLDER">폴더</MenuItem>,
+        <MenuItem value="BOARD">보드</MenuItem>,
+        <MenuItem value="REDIRECT">리다이렉트(바로가기)</MenuItem>
+      ],
+      value: menuCreateFormData.menuType
     },
     {
       name: 'parentId',

--- a/src/libs/API/menu.js
+++ b/src/libs/API/menu.js
@@ -20,7 +20,11 @@ export const getMenuListApi = async () => {
 };
 
 export const getMenuByIdApi = async menuId => {
-  const response = await axios.get(`${baseUrl}/api/v1/menu/${menuId}`);
+  const response = await axios({
+    ...option,
+    method: 'GET',
+    url: `${baseUrl}/api/v1/menu/${menuId}`
+  });
   return response;
 };
 

--- a/src/modules/menu.js
+++ b/src/modules/menu.js
@@ -86,7 +86,7 @@ function* getMenuListSaga() {
 function* getMenuByIdSaga(action) {
   try {
     const res = yield call(getMenuByIdApi, action.menuId);
-    yield put({ type: GET_MENU_BY_ID_SUCCESS, payload: res.data });
+    yield put({ type: GET_MENU_BY_ID_SUCCESS, payload: res.data.data });
   } catch (e) {
     yield put({ type: GET_MENU_BY_ID_ERROR, error: true, payload: e });
   }
@@ -95,7 +95,7 @@ function* getMenuByIdSaga(action) {
 function* createMenuSaga(action) {
   try {
     const res = yield call(createMenuApi, action.menuData);
-    if (res.status === 200 && res.data.code === 1) {
+    if (res.status === 201 && res.data.code === 1) {
       yield put({ type: CREATE_MENU_SUCCESS, payload: res.data });
     } else {
       yield new Promise(resolve => {


### PR DESCRIPTION
- reducer 와 API부분 수정, CreateMenu.js에서 메뉴유형 select 입력 추가

- reducer에서 메뉴생성시 성공코드가 201인데 200이외에는 오류로 처리해서 성공했음에도 실패메시지 나온현상해결
- API에서 getMenuByIdApi에서 따로 만들어둔 option의 값을 넣어주지않아서 헤더의 토큰값이 없어 권한없음으로 나온것. option값을 넣어줘서 해결
- CreateMenu에서 입력받는 state에 menuType값을 넣고 하위 모달의 입력컴포넌트에 select로 선택 할 수 있도록 추가